### PR TITLE
Update citation metadata to 3.0.7

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -16,8 +16,8 @@ authors:
     given-names: Axel
     orcid: "https://orcid.org/0000-0001-6204-6475"
     affiliation: "Institute for Computational Molecular Science, Temple University, Philadelphia, PA, USA"
-version: "3.0.6"
-date-released: "2026-07-20"
+version: "3.0.7"
+date-released: "2026-07-30"
 license: GPL-2.0-or-later
 repository-code: "https://github.com/akohlmey/lammps-gui"
 url: "https://lammps-gui.lammps.org/"

--- a/codemeta.json
+++ b/codemeta.json
@@ -15,7 +15,7 @@
   ],
   "codeRepository": "https://github.com/akohlmey/lammps-gui",
   "dateCreated": "2023",
-  "datePublished": "2026-07-20",
+  "datePublished": "2026-07-30",
   "description": "LAMMPS-GUI is a cross-platform Qt-based graphical application for the LAMMPS molecular dynamics simulation software. It integrates an input-script editor, live simulation execution via the LAMMPS C-library interface, log and thermodynamic-data viewing, interactive plotting, and snapshot/slide-show visualization into a single tool aimed at learning and exploring molecular dynamics with LAMMPS.",
   "developmentStatus": "active",
   "issueTracker": "https://github.com/akohlmey/lammps-gui/issues",
@@ -39,5 +39,5 @@
     "Qt >= 6.2 (Gui, Widgets, Network, Svg)"
   ],
   "url": "https://lammps-gui.lammps.org/",
-  "version": "3.0.6"
+  "version": "3.0.7"
 }


### PR DESCRIPTION
CITATION.cff says `version: 3.0.6`, `date-released: 2026-07-20`. The current stable release is v3.0.7 from 2026-07-30, so citing tools point at the previous release.

Bumped both fields and regenerated codemeta.json with `./update-codemeta.sh`. `cffconvert --validate` passes and a second run of the script produces no diff.